### PR TITLE
Support some editors are using special characters in their name

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,14 +6,14 @@ module.exports = function (file, opts, cb) {
         opts = {};
     }
     if (!opts) opts = {};
-    
+
     var ed = /^win/.test(process.platform) ? 'notepad' : 'vim';
     var editor = opts.editor || process.env.VISUAL || process.env.EDITOR || ed;
     var args = editor.split(/\s+/);
-    var bin = args.shift();
-    
+    var bin = args.join("\\");
+
     var ps = spawn(bin, args.concat([ file ]), { stdio: 'inherit' });
-    
+
     ps.on('exit', function (code, sig) {
         if (typeof cb === 'function') cb(code, sig)
     });


### PR DESCRIPTION
Supports the following case:

```
var e = "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl"
editor(f, { editor: e }, function (er) {
  if (er) return cb(er)
  npm.commands.rebuild(args, cb)
})
```
