### PR TITLE
return child process so consumers can handle errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,8 +8,11 @@ example
 
 ``` js
 var editor = require('editor');
-editor('beep.json', function (code, sig) {
+var process = editor('beep.json', function (code, sig) {
     console.log('finished editing with code ' + code);
+});
+process.on('error', function (error) {
+    console.log('something went wrong: ' + error);
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -17,4 +17,6 @@ module.exports = function (file, opts, cb) {
     ps.on('exit', function (code, sig) {
         if (typeof cb === 'function') cb(code, sig)
     });
+
+    return ps;
 };


### PR DESCRIPTION
If a user does not have `$EDITOR` set and `vim` is not installed (this is the case on a plain Ubuntu 16 for example) `editor` will exit with 

```
Error: spawn vim ENOENT
```

If you consume `editor` in another package there is no way of handling this as you cannot try/catch the spawning.

This could be fixed if the `editor` call would return the child process, so that it'd be possible for the consumer to listen for `error` on the child process.